### PR TITLE
Also "detach" context. Add some nuance to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ That request is a POST with a URL param. Dice expects Multiply running on 4010.
 
 Dice Service: GET http://localhost:[port]/rolldice
 
-Environment variables are important to start up with so that Open Telemetry enables trace parent and baggage. 
+Environment variables are important to start up with so that Open Telemetry
+enables trace parent and baggage. More on options that can be set can be found
+[here](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/) 
 
+```
+# Note: "none" is also a valid value here according to the docs. Seems like
+# maybe something we might want if we truly don't care about the traces.
 OTEL_TRACES_EXPORTER=console
 OTEL_PROPAGATORS=tracecontext,baggage
+```
 
 What I found in this deployment is that the trace parent (transmitted on header `HTTP_TRACEPARENT`) worked without doing anything other than the opentemeletry.rb configuration file.
 

--- a/dice/app/controllers/dice_controller.rb
+++ b/dice/app/controllers/dice_controller.rb
@@ -10,7 +10,7 @@ class DiceController < ApplicationController
     # in order to propogate baggage, the least janky way I've found is to attach it as when you build it
     # it returns a brand new context, but does to associate this context with the current or the current entries
     context_with_baggage = OpenTelemetry::Baggage.build { |b| b.set_value('lost_bag', 'where is it?') }
-    OpenTelemetry::Context.attach(context_with_baggage)
+    token = OpenTelemetry::Context.attach(context_with_baggage)
 
     url = URI.parse("http://localhost:4010/multiply/#{roll}")
     http = Net::HTTP.new(url.host, url.port)
@@ -18,6 +18,8 @@ class DiceController < ApplicationController
 
     response = http.request(request)
     data = JSON.parse(response.body)
+
+    OpenTelemetry::Context.detach(token)
 
     render json: data
   end


### PR DESCRIPTION
I'm aware that this is kind of a throwaway repo but I was messing around with this again this morning and thought I'd at least capture a couple things that might become important down the road. Namely:

* When you attach baggage to a request context, [it would seem that you also need to detach it eventually](https://opentelemetry.io/docs/specs/otel/context/#attach-context). I don't know how this will work in a practical sense when we're actually implementing this thing but I'd hate for a dumb thing like this to bite us.
* It turns out `none` is also a valid value for the `OTEL_TRACES_EXPORTER` env var. I thought it might be good to capture that someplace since we might not want to be dumping extra traces out to the console (since we're already getting traces from the Datadog thingamagig). 